### PR TITLE
Marks the assembly as CLS compliant

### DIFF
--- a/src/Properties/AssemblyInfo.cs
+++ b/src/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using System;
+
+[assembly:CLSCompliant(true)]


### PR DESCRIPTION
In the conversion CLS compliance was dropped. This file reintroduces the `CLSCompliant` attribute.