### PR TITLE
Replace string.Format with string interpolation $"" for CurrentCulture calls

### DIFF
--- a/src/Builder/Operation/ConstructorArgumentResolveOperation.cs
+++ b/src/Builder/Operation/ConstructorArgumentResolveOperation.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
 
 using System;
-using System.Globalization;
 
 namespace Unity.Builder.Operation
 {
@@ -32,9 +31,7 @@ namespace Unity.Builder.Operation
         /// <returns>The description string.</returns>
         public override string ToString()
         {
-            return string.Format(CultureInfo.CurrentCulture,
-                Constants.ConstructorArgumentResolveOperation,
-                ParameterName, _constructorSignature);
+            return $"{Constants.ConstructorArgumentResolveOperation}{ParameterName}{_constructorSignature}";
         }
 
         /// <summary>

--- a/src/Builder/Operation/InvokingConstructorOperation.cs
+++ b/src/Builder/Operation/InvokingConstructorOperation.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
 
 using System;
-using System.Globalization;
 
 namespace Unity.Builder.Operation
 {
@@ -32,9 +31,7 @@ namespace Unity.Builder.Operation
         /// <returns>The string.</returns>
         public override string ToString()
         {
-            return string.Format(CultureInfo.CurrentCulture,
-                Constants.InvokingConstructorOperation,
-                ConstructorSignature);
+            return $"{Constants.InvokingConstructorOperation}{ConstructorSignature}";
         }
     }
 }

--- a/src/Builder/Operation/InvokingMethodOperation.cs
+++ b/src/Builder/Operation/InvokingMethodOperation.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
 
 using System;
-using System.Globalization;
 using System.Reflection;
 
 namespace Unity.Builder.Operation
@@ -33,10 +32,7 @@ namespace Unity.Builder.Operation
         /// <returns>The string.</returns>
         public override string ToString()
         {
-            return string.Format(CultureInfo.CurrentCulture,
-                                 Constants.InvokingMethodOperation,
-                                 TypeBeingConstructed.GetTypeInfo().Name,
-                                 MethodSignature);
+            return $"{Constants.InvokingMethodOperation}{TypeBeingConstructed.GetTypeInfo().Name}{MethodSignature}";
         }
     }
 }

--- a/src/Builder/Operation/MethodArgumentResolveOperation.cs
+++ b/src/Builder/Operation/MethodArgumentResolveOperation.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
 
 using System;
-using System.Globalization;
 using System.Reflection;
 
 namespace Unity.Builder.Operation
@@ -31,9 +30,8 @@ namespace Unity.Builder.Operation
         /// <returns>The description string.</returns>
         public override string ToString()
         {
-            return string.Format(CultureInfo.CurrentCulture,
-                Constants.MethodArgumentResolveOperation,
-                ParameterName, TypeBeingConstructed.GetTypeInfo().Name, MethodSignature);
+            return $"{Constants.MethodArgumentResolveOperation}{ParameterName}" +
+                   $"{TypeBeingConstructed.GetTypeInfo().Name}{MethodSignature}";
         }
 
         /// <summary>

--- a/src/Builder/Operation/PropertyOperation.cs
+++ b/src/Builder/Operation/PropertyOperation.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
 
 using System;
-using System.Globalization;
 using System.Reflection;
 
 namespace Unity.Builder.Operation
@@ -32,9 +31,7 @@ namespace Unity.Builder.Operation
         /// <returns>The string.</returns>
         public override string ToString()
         {
-            return string.Format(CultureInfo.CurrentCulture,
-                                 GetDescriptionFormat(),
-                                 TypeBeingConstructed.GetTypeInfo().Name, PropertyName);
+            return $"{GetDescriptionFormat()}{TypeBeingConstructed.GetTypeInfo().Name}{PropertyName}";
         }
 
         /// <summary>

--- a/src/Exceptions/DependencyMissingException.cs
+++ b/src/Exceptions/DependencyMissingException.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
 
 using System;
-using System.Globalization;
 
 namespace Unity.Exceptions
 {
@@ -42,9 +41,7 @@ namespace Unity.Exceptions
         /// </summary>
         /// <param name="buildKey">The build key of the object begin built.</param>
         public DependencyMissingException(object buildKey)
-            : base(string.Format(CultureInfo.CurrentCulture,
-                Constants.MissingDependency,
-                buildKey))
+            : base($"{Constants.MissingDependency}{buildKey}")
         {
         }
     }

--- a/src/Injection/GenericParameterBase.cs
+++ b/src/Injection/GenericParameterBase.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
 
 using System;
-using System.Globalization;
 using System.Reflection;
 using Unity.Policy;
 using Unity.Utility;
@@ -108,11 +107,7 @@ namespace Unity.Injection
             if (!typeToBuild.GetTypeInfo().IsGenericType)
             {
                 throw new InvalidOperationException(
-                    string.Format(
-                        CultureInfo.CurrentCulture,
-                        Constants.NotAGenericType,
-                        typeToBuild.GetTypeInfo().Name,
-                        _genericParameterName));
+                    $"{Constants.NotAGenericType}{typeToBuild.GetTypeInfo().Name}{_genericParameterName}");
             }
         }
 
@@ -127,11 +122,7 @@ namespace Unity.Injection
             }
 
             throw new InvalidOperationException(
-                string.Format(
-                    CultureInfo.CurrentCulture,
-                    Constants.NoMatchingGenericArgument,
-                    typeToBuild.GetTypeInfo().Name,
-                    _genericParameterName));
+                $"{Constants.NoMatchingGenericArgument}{typeToBuild.GetTypeInfo().Name}{_genericParameterName}");
         }
     }
 }

--- a/src/Injection/GenericResolvedArrayParameter.cs
+++ b/src/Injection/GenericResolvedArrayParameter.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Reflection;
 using Unity.Policy;
 using Unity.ResolverPolicy;
@@ -84,11 +83,7 @@ namespace Unity.Injection
             if (!typeToBuild.GetTypeInfo().IsGenericType)
             {
                 throw new InvalidOperationException(
-                    string.Format(
-                        CultureInfo.CurrentCulture,
-                        Constants.NotAGenericType,
-                        typeToBuild.GetTypeInfo().Name,
-                        _genericParameterName));
+                    $"{Constants.NotAGenericType}{typeToBuild.GetTypeInfo().Name}{_genericParameterName}");
             }
         }
 
@@ -103,11 +98,7 @@ namespace Unity.Injection
             }
 
             throw new InvalidOperationException(
-                string.Format(
-                    CultureInfo.CurrentCulture,
-                    Constants.NoMatchingGenericArgument,
-                    typeToBuild.GetTypeInfo().Name,
-                    _genericParameterName));
+                $"{Constants.NoMatchingGenericArgument}{typeToBuild.GetTypeInfo().Name}{_genericParameterName}");
         }
     }
 }

--- a/src/Injection/InjectionConstructor.cs
+++ b/src/Injection/InjectionConstructor.cs
@@ -1,12 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using Unity.Attributes;
-using Unity.Builder;
 using Unity.Builder.Policy;
 using Unity.Policy;
 using Unity.Registration;
@@ -87,9 +84,7 @@ namespace Unity.Injection
             }
 
             throw new InvalidOperationException(
-                string.Format(CultureInfo.CurrentCulture,
-                    Constants.NoSuchConstructor,
-                    typeToCreate.FullName, string.Empty));
+                $"{Constants.NoSuchConstructor}{typeToCreate.FullName}{string.Empty}");
         }
 
 
@@ -108,10 +103,7 @@ namespace Unity.Injection
             string signature = string.Join(", ", data.Select(p => p.ParameterTypeName).ToArray());
 
             throw new InvalidOperationException(
-                string.Format(CultureInfo.CurrentCulture,
-                    Constants.NoSuchConstructor,
-                    typeToCreate.FullName,
-                    signature));
+                $"{Constants.NoSuchConstructor}{typeToCreate.FullName}{signature}");
         }
 
         private SpecifiedConstructorSelectorPolicy ConstructorByType(Type typeToCreate, Type[] types)
@@ -128,9 +120,10 @@ namespace Unity.Injection
                 }
             }
 
+            var typeNames = string.Join(", ", _types.Select(t => t.Name));
+
             throw new InvalidOperationException(
-                string.Format(CultureInfo.CurrentCulture, Constants.NoSuchConstructor, 
-                typeToCreate.FullName, string.Join(", ", _types.Select(t => t.Name))));
+                $"{Constants.NoSuchConstructor}{typeToCreate.FullName}{typeNames}");
         }
 
         private InjectionParameterValue ToResolvedParameter(ParameterInfo parameter)

--- a/src/Injection/InjectionMethod.cs
+++ b/src/Injection/InjectionMethod.cs
@@ -2,10 +2,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Reflection;
-using Unity.Builder;
 using Unity.Builder.Policy;
 using Unity.Policy;
 using Unity.Registration;
@@ -132,12 +130,10 @@ namespace Unity.Injection
 
         private void ThrowIllegalInjectionMethod(string message, Type typeToCreate)
         {
+            var methodParameterNames = string.Join(", ", _methodParameters.Select(mp => mp.ParameterTypeName));
+
             throw new InvalidOperationException(
-                string.Format(CultureInfo.CurrentCulture,
-                    message,
-                    typeToCreate.GetTypeInfo().Name,
-                    _methodName,
-                    string.Join(", ", _methodParameters.Select(mp => mp.ParameterTypeName))));
+                $"{message}{typeToCreate.GetTypeInfo().Name}{_methodName}{methodParameterNames}");
         }
 
         private static SpecifiedMethodsSelectorPolicy GetSelectorPolicy(IPolicyList policies, Type typeToCreate, string name)

--- a/src/Injection/InjectionProperty.cs
+++ b/src/Injection/InjectionProperty.cs
@@ -102,11 +102,7 @@ namespace Unity.Injection
             if (propInfo == null)
             {
                 throw new InvalidOperationException(
-                    string.Format(
-                        CultureInfo.CurrentCulture,
-                        Constants.NoSuchProperty,
-                        typeToCreate.GetTypeInfo().Name,
-                        propertyName));
+                    $"{Constants.NoSuchProperty}{typeToCreate.GetTypeInfo().Name}{propertyName}");
             }
         }
 

--- a/src/Injection/ResolvedArrayParameter.cs
+++ b/src/Injection/ResolvedArrayParameter.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using Unity.Policy;
@@ -51,11 +50,7 @@ namespace Unity.Injection
                 if (!pv.MatchesType(elementType))
                 {
                     throw new InvalidOperationException(
-                        string.Format(
-                            CultureInfo.CurrentCulture,
-                            Constants.TypesAreNotAssignable,
-                            elementType,
-                            pv.ParameterTypeName));
+                        $"{Constants.TypesAreNotAssignable}{elementType}{pv.ParameterTypeName}");
                 }
             }
         }

--- a/src/ResolverPolicy/OptionalDependencyResolverPolicy.cs
+++ b/src/ResolverPolicy/OptionalDependencyResolverPolicy.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
 
 using System;
-using System.Globalization;
 using System.Reflection;
 using Unity.Builder;
 using Unity.Policy;
@@ -25,9 +24,7 @@ namespace Unity.ResolverPolicy
             if ((type ?? throw new ArgumentNullException(nameof(type))).GetTypeInfo().IsValueType)
             {
                 throw new ArgumentException(
-                    string.Format(CultureInfo.CurrentCulture,
-                        Constants.OptionalDependenciesMustBeReferenceTypes,
-                        type.GetTypeInfo().Name));
+                    $"{Constants.OptionalDependenciesMustBeReferenceTypes}{type.GetTypeInfo().Name}");
             }
 
             DependencyType = type;

--- a/src/Utility/PolicyListExtensions.cs
+++ b/src/Utility/PolicyListExtensions.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
 
 using System;
-using System.Globalization;
 using System.Reflection;
 using Unity.Builder;
 
@@ -314,9 +313,8 @@ namespace Unity.Policy
             if (buildKey is INamedType originalKey)
                 return new NamedTypeBuildKey(newType, originalKey.Name);
 
-            throw new ArgumentException(string.Format(CultureInfo.CurrentCulture,
-                Constants.CannotExtractTypeFromBuildKey,
-                buildKey), nameof(buildKey));
+            throw new ArgumentException(
+                $"{Constants.CannotExtractTypeFromBuildKey}{buildKey}", nameof(buildKey));
         }
 
 


### PR DESCRIPTION
Fixes #73 

I only replaced calls with `CurrentCulture` as replacing `CultureInvariant` is a bit more involved, see https://stackoverflow.com/questions/29333390/specifying-locale-for-string-interpolation-in-c6-roslyn-ctp6 for reference.