### PR TITLE
Fixed typo on "was" (from "war")

### DIFF
--- a/src/Extensions/Lifetime/InstanceLifetime.cs
+++ b/src/Extensions/Lifetime/InstanceLifetime.cs
@@ -41,7 +41,7 @@ namespace Unity
         /// <remarks>
         /// Per Container lifetime allows a registration of an existing or resolved object as 
         /// a scoped singleton in the container it was created or registered. In other words this 
-        /// instance is unique within the container it war registered with. Child or parent 
+        /// instance is unique within the container it was registered with. Child or parent 
         /// containers could have their own instances registered for the same contract.
         /// </remarks>
         /// <value>A new instance of a <see cref="ContainerControlledLifetimeManager"/> object.</value>

--- a/src/Unity.Abstractions.csproj
+++ b/src/Unity.Abstractions.csproj
@@ -71,43 +71,43 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net47'">
     <PackageReference Include="System.Threading.Tasks.Extensions">
-      <Version>4.5.2</Version>
+      <Version>4.5.3</Version>
     </PackageReference>
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net46'">
     <PackageReference Include="System.Threading.Tasks.Extensions">
-      <Version>4.5.2</Version>
+      <Version>4.5.3</Version>
     </PackageReference>
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
     <PackageReference Include="System.Threading.Tasks.Extensions">
-      <Version>4.5.2</Version>
+      <Version>4.5.3</Version>
     </PackageReference>
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.0'">
     <PackageReference Include="System.Threading.Tasks.Extensions">
-      <Version>4.5.2</Version>
+      <Version>4.5.3</Version>
     </PackageReference>
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Threading.Tasks.Extensions">
-      <Version>4.5.2</Version>
+      <Version>4.5.3</Version>
     </PackageReference>
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp1.0'">
     <PackageReference Include="System.Threading.Tasks.Extensions">
-      <Version>4.5.2</Version>
+      <Version>4.5.3</Version>
     </PackageReference>
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
     <PackageReference Include="System.Threading.Tasks.Extensions">
-      <Version>4.5.2</Version>
+      <Version>4.5.3</Version>
     </PackageReference>
   </ItemGroup>
   


### PR DESCRIPTION
Small typo inside PerContainer remarks